### PR TITLE
Delete function mae_loss in udop_unimodel.py

### DIFF
--- a/i-Code-Doc/core/models/udop_unimodel.py
+++ b/i-Code-Doc/core/models/udop_unimodel.py
@@ -494,24 +494,6 @@ class UdopUnimodelForConditionalGeneration(T5ForConditionalGeneration):
         x = x.reshape(shape=(imgs.shape[0], h * w, p**2 * 3))
         return x
 
-    def mae_loss(self, imgs, pred, mask):
-        """
-        imgs: [N, 3, H, W]
-        pred: [N, L, p*p*3]
-        mask: [N, L], 0 is keep, 1 is remove, 
-        """
-        target = self.patchify(imgs)
-        if self.norm_pix_loss:
-            mean = target.mean(dim=-1, keepdim=True)
-            var = target.var(dim=-1, keepdim=True)
-            target = (target - mean) / (var + 1.e-6)**.5
-
-        loss = (pred - target) ** 2
-        loss = loss.mean(dim=-1)  # [N, L], mean loss per patch
-
-        loss = (loss * mask).sum() / mask.sum()  # mean loss on removed patches
-        return loss
-    
     def forward(
         self,
         input_ids: Tensor = None,


### PR DESCRIPTION
While conducting my research, I discovered that the "mae_loss" function is completely unnecessary in the current implementation. This commit removes the function and eliminates confusion for new users.

I must say, your work is truly impressive.